### PR TITLE
Remove FAQ and Contact us from the footer 

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,6 +1,4 @@
-contact_us: /contact-us/
 show_reach: true
-faq: /faq/
 social_media:
   facebook: https://www.facebook.com/YourFBPage
   twitter: https://www.twitter.com/YourTwitter


### PR DESCRIPTION
As requested by Mr.  Hamri
To remove the FAQ and Contact us from the footer as they show irrelevant information 